### PR TITLE
Adding JAX-RS endpoint

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,34 @@
 
 Simple CDI libray for the link:https://github.com/cloudevents/spec[CloudEvents Specification]
 
-== Creating and firing an event:
+== JAX-RS support
+
+Adding the libary to your JAX-RS based application integrates its `/ce` endpoint for handling CloudEvents.
+
+Receiving different multi-cloud events, using the CDI API:
+
+[source,java]
+----
+public class Monitor {
+
+    public void receiveCloudEventFromAWS(@Observes @EventType(name = "aws.s3.object.created") CloudEvent<?> cloudEvent) {
+
+        System.out.println("S3 event: " + cloudEvent);
+
+    }
+    public void receiveCloudEventFromAzure(@Observes @EventType(name = "Microsoft.Storage.BlobCreated") CloudEvent<?> cloudEvent) {
+
+        System.out.println("Azure event: " + cloudEvent);
+
+    }
+}
+----
+
+== Java SE / Weld-SE support
+
+Vanilla CDI support and APIs for CloudEvents
+
+=== Creating and firing an event:
 
 [source,java]
 ----
@@ -29,7 +56,7 @@ public class EventPublisher {
 }
 ----
 
-== Receiving the event
+=== Receiving the event
 
 [source,java]
 ----

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/src/main/java/io/streamzi/cloudevents/JsonMapper.java
+++ b/src/main/java/io/streamzi/cloudevents/JsonMapper.java
@@ -1,11 +1,11 @@
 package io.streamzi.cloudevents;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.streamzi.cloudevents.impl.CloudEventImpl;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.time.ZonedDateTime;
 import java.util.logging.Logger;
 
 public final class JsonMapper {
@@ -13,6 +13,9 @@ public final class JsonMapper {
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final Logger LOGGER = Logger.getLogger(JsonMapper.class.getName());
 
+    {
+        MAPPER.registerModule(new Jdk8Module());
+    }
 
     public static CloudEventImpl fromInputStream(final InputStream inputStream) {
         try {
@@ -21,9 +24,5 @@ public final class JsonMapper {
             LOGGER.severe(e.getMessage());
             throw new IllegalStateException("input was not parseable", e);
         }
-    }
-
-    public static void main(String[] args) {
-        System.out.println(ZonedDateTime.parse("2018-04-23T12:28:22.4579346Z"));
     }
 }

--- a/src/main/java/io/streamzi/cloudevents/impl/CloudEventImpl.java
+++ b/src/main/java/io/streamzi/cloudevents/impl/CloudEventImpl.java
@@ -65,31 +65,31 @@ public class CloudEventImpl<T> implements CloudEvent<T>, Serializable {
 
     @Override
     public Optional<String> getEventTypeVersion() {
-        return Optional.of(eventTypeVersion);
+        return Optional.ofNullable(eventTypeVersion);
     }
 
     @Override
     public Optional<ZonedDateTime> getEventTime() {
-        return Optional.of(eventTime);
+        return Optional.ofNullable(eventTime);
     }
 
     @Override
     public Optional<URI> getSchemaURL() {
-        return Optional.of(schemaURL);
+        return Optional.ofNullable(schemaURL);
     }
 
     @Override
     public Optional<String> getContentType() {
-        return Optional.of(contentType);
+        return Optional.ofNullable(contentType);
     }
 
     @Override
     public Optional<Map> getExtensions() {
-        return Optional.of(extensions);
+        return Optional.ofNullable(extensions);
     }
 
     @Override
     public Optional<T> getData() {
-        return Optional.of(data);
+        return Optional.ofNullable(data);
     }
 }

--- a/src/main/java/io/streamzi/cloudevents/jaxrs/CloudEventEndpoint.java
+++ b/src/main/java/io/streamzi/cloudevents/jaxrs/CloudEventEndpoint.java
@@ -1,0 +1,34 @@
+package io.streamzi.cloudevents.jaxrs;
+
+import io.streamzi.cloudevents.CloudEvent;
+import io.streamzi.cloudevents.EventTypeQualifier;
+import io.streamzi.cloudevents.impl.CloudEventImpl;
+
+
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/ce")
+public class CloudEventEndpoint {
+
+    @Inject
+    private Event<CloudEvent<?>> cloudEventSource;
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response hello(final CloudEventImpl ce) {
+
+        // dispatch to CDI
+        cloudEventSource.select(new EventTypeQualifier(ce.getEventType())).fire(ce);
+
+        return Response.status(Response.Status.ACCEPTED).entity(ce).build();
+    }
+
+}

--- a/src/main/java/io/streamzi/cloudevents/jaxrs/JsonMapperContextResolver.java
+++ b/src/main/java/io/streamzi/cloudevents/jaxrs/JsonMapperContextResolver.java
@@ -1,0 +1,30 @@
+package io.streamzi.cloudevents.jaxrs;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class JsonMapperContextResolver implements ContextResolver<ObjectMapper> {
+
+    private final ObjectMapper mapper;
+
+    public JsonMapperContextResolver() {
+        this.mapper = createObjectMapper();
+    }
+
+    @Override
+    public ObjectMapper getContext(Class<?> type) {
+        return mapper;
+    }
+
+    private ObjectMapper createObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new Jdk8Module());
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        return mapper;
+    }
+}


### PR DESCRIPTION
Simple endpoint that parses incoming Json for cloud event and does a dispatch, based on type.

When adding the `jcloudevents` lib to your JAX-RS project, you can register CDI event handlers like:

```
public class Monitor {

    public void receiveCloudEventFromAWS(@Observes @EventType(name = "aws.s3.object.created") CloudEvent<?> cloudEvent) {

        System.out.println("S3 event: " + cloudEvent);

    }
    public void receiveCloudEventFromAzure(@Observes @EventType(name = "Microsoft.Storage.BlobCreated") CloudEvent<?> cloudEvent) {

        System.out.println("Azure event: " + cloudEvent);

    }
}
```