### PR TITLE
Fixed version number for kafka-cdi dependency

### DIFF
--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.aerogear.kafka</groupId>
             <artifactId>kafka-cdi-extension</artifactId>
-            <version>0.1.1-SNAPSHOT</version>
+            <version>0.0.11-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The dependency on Kafka-CDI had the wrong version number